### PR TITLE
Adding simple script template

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,5 @@ This repository contains the necessary Dockerfiles to build FATES Docker images 
 *Notes*: 
 - The docker images do not contain all the necessary input data, so access to an external data source is necessary.
 - Scripts need to be adjusted to match the internal structure of the docker container.  Template scripts forthcoming.
+
+See the [wiki](https://github.com/NGEET/docker-fates-tutorial/wiki/) for more detailed information on using docker to build and run host land model cases.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,6 @@ This repository contains the necessary Dockerfiles to build FATES Docker images 
 
 *Notes*: 
 - The docker images do not contain all the necessary input data, so access to an external data source is necessary.
-- Scripts need to be adjusted to match the internal structure of the docker container.  Template scripts forthcoming.
+- Scripts need to be adjusted to match the internal structure of the docker container.  See wiki and template script for details.
 
 See the [wiki](https://github.com/NGEET/docker-fates-tutorial/wiki/) for more detailed information on using docker to build and run host land model cases.

--- a/scripts/template-script-docker-1x1brazil.sh
+++ b/scripts/template-script-docker-1x1brazil.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+#===============================================================================
+# CTSM create_newcase template for docker container
+#===============================================================================
+
+#----------------------------------------------------------------------------------
+# RUN SPECIFIC SETUP - USER TO MODIFY
+#----------------------------------------------------------------------------------
+# Set a descriptive name for the case to be run
+export DESCNAME=my-descriptive-case-name
+
+# Set debugging option on or off
+export DEBUGGING=FALSE
+
+# Set the desired compset - use query_config and/or query_testlist for compset names
+export COMPSET=I2000Clm50FatesCruGs
+
+# Set the resolution
+export RESOLUTION=1x1_brazil
+
+# Match the output and input directories to the docker run -v volume mount option
+export CASEDIR=/output          # /output is default
+export INPUTDIR=/inputdata      # /inputdata is default
+
+#----------------------------------------------------------------------------------
+# DOCKER MACHINE SPECIFIC ARGUMENTS - DO NOT CHANGE
+#----------------------------------------------------------------------------------
+export CATEGORY=fates          # For descriptive use in the casename
+export COMPILER=gnu            # Currently only gcc compilers supported
+export MODEL_SOURCE=/CTSM      # Location of ctsm hlm
+export MACH=${HOSTNAME}        # This is set via --hostname=docker option
+
+#----------------------------------------------------------------------------------
+# SETUP DIRECTORY - USER SHOULD NOT NEED TO CHANGE THESE
+#----------------------------------------------------------------------------------
+# Switch to host land model
+echo "Running with CTSM location: "${MODEL_SOURCE}
+cd ${MODEL_SOURCE}/cime/scripts
+
+# Setup githash to append to test directory name for reproducability
+export CLMHASH=`cd ../../;git log -n 1 --format=%h`
+export FATESHASH=`(cd ../../src/fates;git log -n 1 --format=%h)`
+export GITHASH="C"${CLMHASH}"-F"${FATESHASH}
+
+# Setup build, run and output directory name
+export CASENAME=${CASEDIR}/${DESCNAME}.${CATEGORY}.${MACH}.${GITHASH}
+
+#----------------------------------------------------------------------------------
+# CREATE THE CASE
+#----------------------------------------------------------------------------------
+echo "Calling create_newcase"
+./create_newcase --case=${CASENAME} --res=${RESOLUTION} --compset=${COMPSET} --mach=${MACH} --compiler=${COMPILER} --run-unsupported
+
+# Change to the created case directory
+echo "Changing to case directory: " ${CASENAME}
+cd ${CASENAME}
+
+#----------------------------------------------------------------------------------
+# UPDATE CASE CONFIGURATION - user to update or add as necessary
+#----------------------------------------------------------------------------------
+echo "Calling xmlchange"
+
+# Change the run time settings
+./xmlchange STOP_N=2
+./xmlchange STOP_OPTION=nyears
+
+# Change the debugging setup to match above argument
+./xmlchange DEBUG=${DEBUGGING}
+
+# Override the .cime configuration default to match the above argument for dir locations
+./xmlchange CIME_OUTPUT_ROOT=${CASEDIR}
+./xmlchange DIN_LOC_ROOT=${INPUTDIR}
+./xmlchange DIN_LOC_ROOT_CLMFORC=${INPUTDIR}/atm/datm7
+
+# Change the output dir for short term archives (i.e. the run logs) - do not change
+./xmlchange DOUT_S_ROOT=${CASENAME}/run
+
+#----------------------------------------------------------------------------------
+# SETUP AND BUILD THE CASE
+#----------------------------------------------------------------------------------
+echo "Setting up case"
+./case.setup
+echo "Building case"
+./case.build
+
+# MANUALLY SUBMIT CASE
+echo "To submit the case change directory to ${CASENAME} and run ./case.submit"


### PR DESCRIPTION
### Description:
<!--- Brief description of the changes being made -->
Adding template script

### Details
<!--- Place details of the changes and any links to relevant issues or discussions here -->
This PR adds a simple 1x1brazil template script.  I've attempted to setup the template with descriptive comments to help new users orient themselves to how the `docker run` `-v` volume mount options will work in tandem with the `.cime` configuration folder and the script itself.  

### Collaborators:
<!--- Note those that specifically helped you develop the changes -->

### Docker image component versions
<!--- Identify the specific version of the OS, host land model, and fates version updated.  This should have been updated in the Dockerfile `LABEL`.  Links to the dockerhub or github commit are encouraged. -->
Base OS: N/A
Host land model: N/A
FATES tag: N/A

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] `LABEL` meta data updated in Dockerfile
- [x] Case build and run successful
- [ ] Autobuild on personal repo successful
- [ ] ngeetropics dockerhub repository created and build settings initialized  (as necessary)
- [ ] ngeetropics readme updated (as necessary)
- [ ] Tag pushed to this repository (post-merge)

### Test results
<!--- Include location to build and test case results . -->
Build test on personal repo: 
Test case results: N/A
