### PR TITLE
Create new ctsm-gcc image with ctsm5.1.dev022

### DIFF
--- a/docker/baseos/gcc/gcc650_conda/Dockerfile
+++ b/docker/baseos/gcc/gcc650_conda/Dockerfile
@@ -1,0 +1,162 @@
+# ----------------------------------------------------------------------
+# Debian baseOS docker container to use with HLM builds
+# ----------------------------------------------------------------------
+
+FROM gcc:6.5
+LABEL maintainer.name="Gregory Lemieux" \
+      maintainer.email="glemieux@lbl.gov" \
+      author.name="S.P. Serbin" \
+      author.email="sserbin@bnl.gov" \
+      description="GCC-based image loaded with necessary dependencies for building FATES-HLM images"
+
+# Set a few variables that can be used to control the docker build
+ARG OPENMPI_VERSION=2.1.5
+ARG HDF5_VERSION=1.10.4
+ARG NETCDF_VERSION=4.6.2
+ARG NETCDF_FORTRAN_VERSION=4.4.4
+
+# echo back options
+RUN echo $NCPUS
+RUN echo $OPENMPI_VERSION
+RUN echo $HDF5_VERSION
+RUN echo $NETCDF_VERSION
+RUN echo $NETCDF_FORTRAN_VERSION
+
+ENV PATH=/usr/local/bin:$PATH
+ENV LD_LIBRARY_PATH=/usr/local/lib64:$LD_LIBRARY_PATH
+ENV PATH=/usr/local/hdf5/bin:$PATH
+ENV PATH=/usr/local/netcdf/bin:$PATH
+ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/hdf5/lib
+ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/netcdf/lib
+
+# Update the system and install initial dependencies
+RUN apt-get update -y \
+    && apt-get install -y \
+    cmake \
+    git \
+    subversion \
+    bzip2 \
+    libgmp3-dev \
+    m4 \
+    wget \
+    libcurl4-openssl-dev \
+    zlib1g-dev \
+    libncurses5-dev \
+    libxml2 \
+    libxml2-dev \
+    csh \
+    liblapack-dev \
+    libblas-dev \
+    liblapack-dev \
+    libffi6 \
+    libffi-dev \
+    libxml-libxml-perl \
+    libxml2-utils \
+    vim \
+    libudunits2-0 \
+    libudunits2-dev \
+    udunits-bin \
+    htop \
+    python2.7 \
+    python-dev \
+    python-pip \
+    python3 \
+    python3-pip \
+    apt-utils \
+    ftp \
+    apt-transport-https \
+    locales
+
+    ## Install program to configure locales
+RUN dpkg-reconfigure locales && \
+  locale-gen C.UTF-8 && \
+    /usr/sbin/update-locale LANG=C.UTF-8
+RUN echo 'en_US.UTF-8 UTF-8' >> /etc/locale.gen && \
+      locale-gen
+   ## Set default locale for the environment
+ENV LC_ALL C.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US.UTF-8
+
+   ## check locales
+RUN locale -a
+
+   ## compile openMPI
+RUN echo "*** Compiling openMPI " ${OPENMPI_VERSION}
+RUN cd / \
+    && wget https://download.open-mpi.org/release/open-mpi/v2.1/openmpi-${OPENMPI_VERSION}.tar.gz \
+    && tar -zxvf openmpi-${OPENMPI_VERSION}.tar.gz \
+    && cd openmpi-${OPENMPI_VERSION} \
+    && export PATH=/usr/local/bin:$PATH \
+    && export LD_LIBRARY_PATH=/usr/local/lib64:$LD_LIBRARY_PATH \
+    && ./configure --enable-static \
+    && make \
+    && make install \
+    && cd / \
+    && rm -r openmpi-${OPENMPI_VERSION} \
+    && rm openmpi-${OPENMPI_VERSION}.tar.gz \
+    && ldconfig
+
+## Compile Expat XML parser
+RUN echo "*** Compiling Expat XML parser"
+RUN cd / \
+    && wget https://github.com/libexpat/libexpat/releases/download/R_2_2_6/expat-2.2.6.tar.bz2 \
+    && tar -xvjf expat-2.2.6.tar.bz2 \
+    && cd expat-2.2.6 \
+    && ./configure \
+    && make \
+    && make install \
+    && cd / \
+    && rm -r expat-2.2.6 \
+    && rm expat-2.2.6.tar.bz2
+
+## HDF5
+RUN echo "*** Compiling HDF5 " ${HDF5_VERSION}
+RUN cd / \
+    && mkdir -p /usr/local/hdf5 \
+    && wget https://s3.amazonaws.com/hdf-wordpress-1/wp-content/uploads/manual/HDF5/HDF5_1_10_4/hdf5-1.10.4.tar.gz \
+    && tar -zxvf hdf5-1.10.4.tar.gz \
+    && cd hdf5-1.10.4 \
+    && CC=mpicc ./configure --enable-fortran --enable-parallel --prefix=/usr/local/hdf5 \
+    && make \
+    && make install \
+    && export PATH=/usr/local/hdf5/bin:$PATH \
+    && export LD_LIBRARY_PATH=/usr/local/hdf5/lib/libhdf5 \
+    && cd / \
+    && rm -r hdf5-1.10.4 \
+    && rm hdf5-1.10.4.tar.gz
+
+## netCDF
+RUN echo "*** Compiling netCDF " ${NETCDF_VERSION}
+RUN cd / \
+    && mkdir -p /usr/local/netcdf \
+    && wget https://www.unidata.ucar.edu/downloads/netcdf/ftp/netcdf-c-4.6.2.tar.gz \
+    && tar -zxvf netcdf-c-4.6.2.tar.gz \
+    && cd netcdf-c-4.6.2 \
+    && export H5DIR=/usr/local/hdf5 \
+    && export NCDIR=/usr/local/netcdf \
+    && CC=mpicc CPPFLAGS=-I${H5DIR}/include LDFLAGS=-L${H5DIR}/lib ./configure --enable-parallel-tests --prefix=${NCDIR} \
+    && make \
+    && make install \
+    && export PATH=/usr/local/netcdf/bin:$PATH \
+    && export LD_LIBRARY_PATH=/usr/local/netcdf/lib 
+
+## "Compile netCDF-Fortran"
+RUN echo "*** Compiling netCDF fortran " ${NETCDF_FORTRAN_VERSION}
+RUN wget https://www.unidata.ucar.edu/downloads/netcdf/ftp/netcdf-fortran-4.4.4.tar.gz \
+    && tar -zxvf netcdf-fortran-4.4.4.tar.gz \
+    && cd netcdf-fortran-4.4.4 \
+    && export NCDIR=/usr/local/netcdf \
+    && export NFDIR=/usr/local/netcdf \
+    && CPPFLAGS=-I${NCDIR}/include LDFLAGS=-L${NCDIR}/lib ./configure --prefix=${NFDIR} --enable-parallel-tests \
+    && make \
+    && make install
+
+## Final cleanup
+RUN cd / \
+    && rm -r netcdf-c-4.6.2 \
+    && rm netcdf-c-4.6.2.tar.gz \
+    && rm -r netcdf-fortran-4.4.4 \
+    && rm netcdf-fortran-4.4.4.tar.gz
+
+### EOF

--- a/docker/baseos/gcc/gcc650_conda/hooks/post_push
+++ b/docker/baseos/gcc/gcc650_conda/hooks/post_push
@@ -1,0 +1,3 @@
+#!/bin/bash
+docker tag $IMAGE_NAME $DOCKER_REPO:latest
+docker push $DOCKER_REPO:latest

--- a/docker/ctsm/cime_config/config
+++ b/docker/ctsm/cime_config/config
@@ -1,0 +1,2 @@
+[main]
+CIME_MODEL=cesm

--- a/docker/ctsm/cime_config/config_compilers.xml
+++ b/docker/ctsm/cime_config/config_compilers.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<config_compilers version="2.0">
+   <!-- customize these fields as appropriate for your
+        system. Examples are prodived for Mac OS X systems with
+        homebrew and macports. -->
+
+   <compiler COMPILER="gnu" MACH="docker">
+     <SUPPORTS_CXX>TRUE</SUPPORTS_CXX>
+     <CPPDEFS>
+       <append MODEL="gptl"> -DHAVE_VPRINTF -DHAVE_GETTIMEOFDAY -DHAVE_BACKTRACE </append>
+     </CPPDEFS>
+     <FFLAGS>
+       <append DEBUG="FALSE"> </append>
+       <append DEBUG="TRUE"> -g -fbacktrace -fbounds-check -ffpe-trap=invalid,zero,overflow</append>
+     </FFLAGS>
+     <SLIBS>
+       <append> -L$ENV{HDF5_HOME}/lib -lhdf5_fortran -lhdf5 -lhdf5_hl -lhdf5hl_fortran </append>
+       <append> -L$ENV{NETCDF_PATH}/lib/ -lnetcdff -lnetcdf -lcurl -lblas -llapack </append>
+     </SLIBS>  
+     <SCC MPILIB="mpi-serial">gcc</SCC>
+     <SFC MPILIB="mpi-serial">gfortran</SFC>
+   </compiler>
+
+</config_compilers>

--- a/docker/ctsm/cime_config/config_machines.xml
+++ b/docker/ctsm/cime_config/config_machines.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+<config_machines>
+   <machine MACH="docker">
+      <!-- customize these fields as appropriate for your system (max tasks) and
+           desired layout (change '${HOME}/projects' to your
+           prefered location). -->
+      <DESC>Containerized FATES-HLM</DESC>
+      <NODENAME_REGEX>dockernode</NODENAME_REGEX>
+      <OS>linux</OS>
+      <COMPILERS>gnu</COMPILERS>
+      <MPILIBS>openmpi,mpi-serial</MPILIBS>
+      <CIME_OUTPUT_ROOT>/output</CIME_OUTPUT_ROOT>
+      <DIN_LOC_ROOT>/inputdata</DIN_LOC_ROOT>
+      <DIN_LOC_ROOT_CLMFORC>/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
+      <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
+      <BASELINE_ROOT>/baselines</BASELINE_ROOT>
+      <CCSM_CPRNC>$CIMEROOT/tools/cprnc/build/cprnc</CCSM_CPRNC>
+      <GMAKE>make</GMAKE>
+      <GMAKE_J>1</GMAKE_J>
+      <BATCH_SYSTEM>none</BATCH_SYSTEM>
+      <SUPPORTED_BY>glemieux at lbl dot gov</SUPPORTED_BY>
+      <MAX_TASKS_PER_NODE>4</MAX_TASKS_PER_NODE>
+      <MAX_MPITASKS_PER_NODE>1</MAX_MPITASKS_PER_NODE>
+      <PROJECT_REQUIRED>FALSE</PROJECT_REQUIRED>
+      <mpirun mpilib="mpi-serial">
+	<executable></executable>
+      </mpirun>
+      <mpirun mpilib="default">
+	<executable>mpirun</executable>
+	<arguments>
+	  <arg name="anum_tasks"> -np $TOTALPES</arg>
+	  <arg name="tasks_per_node"> -npernode $MAX_TASKS_PER_NODE</arg>
+	</arguments>
+      </mpirun>
+      <module_system type="none"/>
+      <environment_variables>
+        <env name="HDF5_HOME">/usr/local/hdf5</env>
+        <env name="NETCDF_PATH">/usr/local/netcdf</env>
+    </environment_variables>
+   </machine>
+
+</config_machines>

--- a/docker/ctsm/ctsm-gcc650/Dockerfile
+++ b/docker/ctsm/ctsm-gcc650/Dockerfile
@@ -29,12 +29,21 @@ RUN mkdir -p inputdata \
     && mkdir -p .cime 
 
 ## TODO: merge above into single large RUN command?
-## Clone CTSM model
+## Clone CTSM model and grab the docker-specific cime config directory from github
 RUN git -c http.sslVerify=false clone https://github.com/ESCOMP/CTSM.git \
     && cd CTSM \
     && git describe \
     && git checkout ctsm5.1.dev022 \
     && ./manage_externals/checkout_externals \
-    && git describe 
+    && git describe \
+    && cd src/fates/ \
+    && git describe \
+    && cd /.cime \
+    && wget https://raw.githubusercontent.com/glemieux/docker-fates-tutorial/develop/docker/ctsm/cime_config/config \ 
+    && wget https://raw.githubusercontent.com/glemieux/docker-fates-tutorial/develop/docker/ctsm/cime_config/config_compilers.xml \
+    && wget https://raw.githubusercontent.com/glemieux/docker-fates-tutorial/develop/docker/ctsm/cime_config/config_machines.xml
 
+## Should the above wgets be changed to COPY?  We would have to then include the cime directory with every dockerfile.
+## The problem with wget is that it has no knowledge of whether or not the files changed state so a `docker build .` won't
+## really build a new image if nothing else is changed in the Dockerfile.
 ### EOF

--- a/docker/ctsm/ctsm-gcc650/Dockerfile
+++ b/docker/ctsm/ctsm-gcc650/Dockerfile
@@ -39,9 +39,9 @@ RUN git -c http.sslVerify=false clone https://github.com/ESCOMP/CTSM.git \
     && cd src/fates/ \
     && git describe \
     && cd /.cime \
-    && wget https://raw.githubusercontent.com/glemieux/docker-fates-tutorial/develop/docker/ctsm/cime_config/config \ 
-    && wget https://raw.githubusercontent.com/glemieux/docker-fates-tutorial/develop/docker/ctsm/cime_config/config_compilers.xml \
-    && wget https://raw.githubusercontent.com/glemieux/docker-fates-tutorial/develop/docker/ctsm/cime_config/config_machines.xml
+    && wget https://raw.githubusercontent.com/glemieux/docker-fates-tutorial/master/docker/ctsm/cime_config/config \ 
+    && wget https://raw.githubusercontent.com/glemieux/docker-fates-tutorial/master/docker/ctsm/cime_config/config_compilers.xml \
+    && wget https://raw.githubusercontent.com/glemieux/docker-fates-tutorial/master/docker/ctsm/cime_config/config_machines.xml
 
 ## Should the above wgets be changed to COPY?  We would have to then include the cime directory with every dockerfile.
 ## The problem with wget is that it has no knowledge of whether or not the files changed state so a `docker build .` won't

--- a/docker/ctsm/ctsm-gcc650/Dockerfile
+++ b/docker/ctsm/ctsm-gcc650/Dockerfile
@@ -1,0 +1,40 @@
+# --------------------------------------------------------------------------------------------
+# CTSM host land model with experimental FATES land component docker container on GCC-base OS
+# --------------------------------------------------------------------------------------------
+
+FROM ngeetropics/hlmbase-gcc650:v.0.0.0
+LABEL maintainer.name="Gregory Lemieux" \
+      maintainer.email="glemieux@lbl.gov" \
+      author.name="Gregory Lemieux" \
+      author.email="glemieux@lbl.gov" \
+      description="CTSM host land model on GCC-base OS" \
+      version.fates="sci.1.43.2_api.14.2.0" \
+      version.hlm="ctsm5.1.dev022" \
+      version.baseos="gcc6.5"
+
+# setting gmake
+RUN ln -s /usr/bin/make /usr/bin/gmake
+
+# Setup environment variables.  This is necessary for os.environ calls from case.py in CIME
+ENV USER=fatesuser
+
+# Add user directory structure.  This is necessary for CIME
+RUN useradd -m $USER -u 9001
+
+## create data mount points in container - should change this to /mnt or something more generic in machines files
+RUN mkdir -p inputdata \
+    && mkdir -p output \
+    && mkdir -p scripts \
+    && mkdir -p baselines \
+    && mkdir -p .cime 
+
+## TODO: merge above into single large RUN command?
+## Clone CTSM model
+RUN git -c http.sslVerify=false clone https://github.com/ESCOMP/CTSM.git \
+    && cd CTSM \
+    && git describe \
+    && git checkout ctsm5.1.dev022 \
+    && ./manage_externals/checkout_externals \
+    && git describe 
+
+### EOF

--- a/docker/ctsm/ctsm-gcc650/hooks/post_push
+++ b/docker/ctsm/ctsm-gcc650/hooks/post_push
@@ -1,0 +1,3 @@
+#!/bin/bash
+docker tag $IMAGE_NAME $DOCKER_REPO:latest
+docker push $DOCKER_REPO:latest

--- a/docker/fates-ctsm/fates-ctsm-gcc650/Dockerfile
+++ b/docker/fates-ctsm/fates-ctsm-gcc650/Dockerfile
@@ -39,9 +39,9 @@ RUN git -c http.sslVerify=false clone https://github.com/ESCOMP/CTSM.git \
     && cd src/fates/ \
     && git describe \
     && cd /.cime \
-    && wget https://raw.githubusercontent.com/glemieux/docker-fates-tutorial/develop/docker/fates-ctsm/cime_config/config \ 
-    && wget https://raw.githubusercontent.com/glemieux/docker-fates-tutorial/develop/docker/fates-ctsm/cime_config/config_compilers.xml \
-    && wget https://raw.githubusercontent.com/glemieux/docker-fates-tutorial/develop/docker/fates-ctsm/cime_config/config_machines.xml
+    && wget https://raw.githubusercontent.com/glemieux/docker-fates-tutorial/master/docker/fates-ctsm/cime_config/config \ 
+    && wget https://raw.githubusercontent.com/glemieux/docker-fates-tutorial/master/docker/fates-ctsm/cime_config/config_compilers.xml \
+    && wget https://raw.githubusercontent.com/glemieux/docker-fates-tutorial/master/docker/fates-ctsm/cime_config/config_machines.xml
 
 ## Should the above wgets be changed to COPY?  We would have to then include the cime directory with every dockerfile.
 ## The problem with wget is that it has no knowledge of whether or not the files changed state so a `docker build .` won't


### PR DESCRIPTION
### Description:
Now that fates is up-to-date with the ctsm master branch, we should provide a ctsm image based on the standard ctsm tags.

### Details
This PR uses ctsm5.1.dev022 which corresponds to fates tag sci.1.43.2_api.14.2.0

### Collaborators:

### Docker image component versions
<!--- Identify the specific version of the OS, host land model, and fates version updated.  This should have been updated in the Dockerfile `LABEL`.  Links to the dockerhub or github commit are encouraged. -->
Base OS: https://hub.docker.com/r/ngeetropics/hlmbase-gcc650
Host land model: https://github.com/ESCOMP/CTSM/releases/tag/ctsm5.1.dev022
FATES tag: https://github.com/NGEET/fates/releases/tag/sci.1.43.2_api.14.2.0

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] `LABEL` meta data updated in Dockerfile
- [x] Case build and run successful
- [x] Autobuild on personal repo successful
- [x] ngeetropics dockerhub repository created and build settings initialized  (as necessary)
- [ ] ngeetropics readme updated (as necessary)
- [ ] Tag pushed to this repository (post-merge)

### Test results
<!--- Include location to build and test case results . -->
Build test on personal repo: 
Test case results: 
