### PR TITLE
Quick fix to location of cime_config files

### DIFF
--- a/docker/ctsm/ctsm-gcc650/Dockerfile
+++ b/docker/ctsm/ctsm-gcc650/Dockerfile
@@ -39,9 +39,9 @@ RUN git -c http.sslVerify=false clone https://github.com/ESCOMP/CTSM.git \
     && cd src/fates/ \
     && git describe \
     && cd /.cime \
-    && wget https://raw.githubusercontent.com/glemieux/docker-fates-tutorial/master/docker/ctsm/cime_config/config \ 
-    && wget https://raw.githubusercontent.com/glemieux/docker-fates-tutorial/master/docker/ctsm/cime_config/config_compilers.xml \
-    && wget https://raw.githubusercontent.com/glemieux/docker-fates-tutorial/master/docker/ctsm/cime_config/config_machines.xml
+    && wget https://raw.githubusercontent.com/NGEET/docker-fates-tutorial/master/docker/ctsm/cime_config/config \ 
+    && wget https://raw.githubusercontent.com/NGEET/docker-fates-tutorial/master/docker/ctsm/cime_config/config_compilers.xml \
+    && wget https://raw.githubusercontent.com/NGEET/docker-fates-tutorial/master/docker/ctsm/cime_config/config_machines.xml
 
 ## Should the above wgets be changed to COPY?  We would have to then include the cime directory with every dockerfile.
 ## The problem with wget is that it has no knowledge of whether or not the files changed state so a `docker build .` won't


### PR DESCRIPTION
### Description:
Forgot to change the call to the `wget` for the cime_config files from my personal fork to the ngeet org.

### Details

### Collaborators:



### Docker image component versions
<!--- Identify the specific version of the OS, host land model, and fates version updated.  This should have been updated in the Dockerfile `LABEL`.  Links to the dockerhub or github commit are encouraged. -->
Base OS: https://hub.docker.com/r/ngeetropics/hlmbase-gcc650
 Host land model: https://github.com/ESCOMP/CTSM/releases/tag/ctsm5.1.dev022
 FATES tag: https://github.com/NGEET/fates/releases/tag/sci.1.43.2_api.14.2.0

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] `LABEL` meta data updated in Dockerfile
- [ ] Case build and run successful
- [ ] Autobuild on personal repo successful
- [ ] ngeetropics dockerhub repository created and build settings initialized  (as necessary)
- [ ] ngeetropics readme updated (as necessary)
- [ ] Tag pushed to this repository (post-merge)

### Test results
<!--- Include location to build and test case results . -->
Build test on personal repo: 
Test case results: 
